### PR TITLE
Fix self-reference of sqlConf and static configuration registration check.

### DIFF
--- a/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServer.scala
+++ b/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServer.scala
@@ -76,7 +76,7 @@ object SQLServer extends Logging {
     initDaemon(log)
 
     // Initializes Spark variables depending on execution modes
-    SQLServerEnv.sqlConf.sqlServerExecutionMode  match {
+    SQLServerEnv.sqlConf.sqlServerExecutionMode match {
       case "single-session" | "multi-session" =>
         SQLServerEnv.sqlServListener
         SQLServerEnv.uiTab
@@ -84,6 +84,7 @@ object SQLServer extends Logging {
           SQLServerEnv.uiTab.foreach(_.detach())
           SQLServerEnv.sparkContext.stop()
         }
+      case _ =>
     }
 
     val sqlServer = new SQLServer()

--- a/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServerConf.scala
+++ b/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServerConf.scala
@@ -216,7 +216,8 @@ class SQLServerConf(conf: SQLConf) {
    * yet, return `defaultValue` in [[ConfigEntry]].
    */
   private def getConf[T](entry: ConfigEntry[T]): T = {
-    require(sqlConfEntries.get(entry.key) == entry, s"$entry is not registered")
+    require(sqlConfEntries.get(entry.key) == entry || SQLConf.staticConfKeys.contains(entry.key),
+      s"$entry is not registered")
     entry.readFrom(reader)
   }
 }

--- a/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServerEnv.scala
+++ b/sql/sql-server/src/main/scala/org/apache/spark/sql/server/SQLServerEnv.scala
@@ -60,7 +60,7 @@ object SQLServerEnv extends Logging {
 
   lazy val sqlConf: SQLConf = _sqlContext.map(_.conf).getOrElse {
     val newSqlConf = new SQLConf()
-    mergeSparkConf(sqlConf, sparkConf)
+    mergeSparkConf(newSqlConf, sparkConf)
     newSqlConf
   }
 


### PR DESCRIPTION
Fixes #19.

Changed the self-reference within the `sqlConf` lazy val to `newSqlConf` when merging in the spark configuration parameters.

I also found an issue where the statically registered configuration items were not working because the static registry was not checked in `getConf`.