### PR TITLE
Add a few fixes for unit tests.

### DIFF
--- a/sql/sql-server/src/test/scala/org/apache/spark/sql/server/SparkPgServerTestUtils.scala
+++ b/sql/sql-server/src/test/scala/org/apache/spark/sql/server/SparkPgServerTestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.server
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.sql._
-import java.util.{Properties, UUID}
+import java.util.{Properties, TimeZone, UUID}
 
 import scala.collection.mutable
 import scala.concurrent.Promise
@@ -95,7 +95,7 @@ class SparkPgSQLServerTest(
   private val className = SQLServer.getClass.getCanonicalName.stripSuffix("$")
   private val logFileMask = s"starting $className, logging to "
   private val successStartLines = Set(
-    "PgProtocolService: Start running the SQL server",
+    "PgService: Start running the SQL server",
     "Recovery mode 'ZOOKEEPER' enabled"
   )
   private val startScript = "../../sbin/start-sql-server.sh".split("/").mkString(File.separator)
@@ -165,6 +165,7 @@ class SparkPgSQLServerTest(
        | --master local
        | --driver-class-path $testTempDir
        | --driver-java-options -Dlog4j.debug
+       | --conf spark.sql.session.timeZone=GMT
        | --conf spark.ui.enabled=false
        | --conf spark.sql.warehouse.dir=$testTempDir/spark-warehouse
        | --conf ${SQLServerConf.SQLSERVER_PORT.key}=$port
@@ -355,6 +356,7 @@ trait PgJdbcTestBase {
       props.put("sslfactory", "org.postgresql.ssl.NonValidatingFactory")
     }
 
+    TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
     DriverManager.getConnection(jdbcUri, props)
   }
 

--- a/sql/sql-server/src/test/scala/org/apache/spark/sql/server/service/postgresql/protocol/v3/PgRowConvertersSuite.scala
+++ b/sql/sql-server/src/test/scala/org/apache/spark/sql/server/service/postgresql/protocol/v3/PgRowConvertersSuite.scala
@@ -72,6 +72,7 @@ object UDT {
 class PgRowConvertersSuite extends SparkFunSuite {
 
   private val conf = new SQLConf()
+  conf.setConf(SQLConf.SESSION_LOCAL_TIMEZONE, "GMT")
 
   test("primitive types") {
     Seq(

--- a/sql/sql-server/src/test/scala/org/apache/spark/sql/server/service/postgresql/protocol/v3/PgV3ProtocolScenarioSuite.scala
+++ b/sql/sql-server/src/test/scala/org/apache/spark/sql/server/service/postgresql/protocol/v3/PgV3ProtocolScenarioSuite.scala
@@ -39,7 +39,7 @@ class PgV3ProtocolScenarioSuite extends PgV3ProtocolTest {
 
   testIfSupported("unsupported SQL strings") {
     def expectedErrorMessage(message: String, cmd: String): Seq[String] =
-      Seq(s"Exception detected in '$message'", s"Operation not allowed: $cmd")
+      Seq(s"Exception detected in `$message`", s"Operation not allowed: $cmd")
 
     Seq("COMMIT", "ROLLBACK").foreach { cmd =>
       val e1 = intercept[Exception] {


### PR DESCRIPTION
When running these tests in a time zone that has daylight savings the timestamp conversions may be off by an hour, so set the time zone for the client/server to GMT for consistency during tests. Also updated a couple messages that were being compared because they appeared to be out of date.